### PR TITLE
fix: add temporary dependency to the client

### DIFF
--- a/packages/connector-management-sdk/pom.xml
+++ b/packages/connector-management-sdk/pom.xml
@@ -250,6 +250,13 @@
             <version>${javax-annotation-version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Temporary change until bug with generator is resolved -->
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/packages/kafka-instance-sdk/pom.xml
+++ b/packages/kafka-instance-sdk/pom.xml
@@ -250,6 +250,12 @@
             <version>${javax-annotation-version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Temporary change until bug with generator is resolved -->
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/packages/kafka-management-sdk/pom.xml
+++ b/packages/kafka-management-sdk/pom.xml
@@ -250,6 +250,12 @@
             <version>${javax-annotation-version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Temporary change until bug with generator is resolved -->
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/packages/registry-management-sdk/pom.xml
+++ b/packages/registry-management-sdk/pom.xml
@@ -250,6 +250,12 @@
             <version>${javax-annotation-version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Temporary change until bug with generator is resolved -->
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <distributionManagement>


### PR DESCRIPTION
Fixes problem of not being able to use SDK outside quarkus

We do not see that problem because our examples and other usage uses Quarkus bom with that dependency provided explicitly, however if users using different restful layer they will get error about GenericType not being present.

```
While trying to use

com.redhat.cloud:kafka-instance-sdk:jar:0.14.0

With Quarkus we get a

java.lang.NoClassDefFoundError: jakarta/ws/rs/core/Configuration
```

Issue have been already resolved upstream (but not for resteasy): https://github.com/OpenAPITools/openapi-generator/issues/8320 

In long run we might:
- Contribute fix to the upstream to fix resteasy
- Move to plain java client (controversial)
