### PR TITLE
fix: set config property `openApiNullable=false` for Kafka instance API

### DIFF
--- a/packages/kafka-instance-sdk/src/main/java/com/openshift/cloud/api/kas/auth/invoker/JSON.java
+++ b/packages/kafka-instance-sdk/src/main/java/com/openshift/cloud/api/kas/auth/invoker/JSON.java
@@ -2,7 +2,6 @@ package com.openshift.cloud.api.kas.auth.invoker;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.jsr310.*;
 
 import java.text.DateFormat;
@@ -22,8 +21,6 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.setDateFormat(new RFC3339DateFormat());
-    JsonNullableModule jnm = new JsonNullableModule();
-    mapper.registerModule(jnm);
     mapper.registerModule(new JavaTimeModule());
   }
 

--- a/packages/kafka-instance-sdk/src/main/java/com/openshift/cloud/api/kas/auth/models/Partition.java
+++ b/packages/kafka-instance-sdk/src/main/java/com/openshift/cloud/api/kas/auth/models/Partition.java
@@ -25,10 +25,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
-import org.openapitools.jackson.nullable.JsonNullable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.openapitools.jackson.nullable.JsonNullable;
-import java.util.NoSuchElementException;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -55,7 +51,7 @@ public class Partition {
   private List<Node> isr = null;
 
   public static final String JSON_PROPERTY_LEADER = "leader";
-  private JsonNullable<Node> leader = JsonNullable.<Node>undefined();
+  private Node leader;
 
   public Partition() { 
   }
@@ -158,8 +154,8 @@ public class Partition {
 
 
   public Partition leader(Node leader) {
-    this.leader = JsonNullable.<Node>of(leader);
     
+    this.leader = leader;
     return this;
   }
 
@@ -169,26 +165,18 @@ public class Partition {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonIgnore
-
-  public Node getLeader() {
-        return leader.orElse(null);
-  }
-
   @JsonProperty(JSON_PROPERTY_LEADER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public JsonNullable<Node> getLeader_JsonNullable() {
+  public Node getLeader() {
     return leader;
   }
-  
-  @JsonProperty(JSON_PROPERTY_LEADER)
-  public void setLeader_JsonNullable(JsonNullable<Node> leader) {
-    this.leader = leader;
-  }
 
+
+  @JsonProperty(JSON_PROPERTY_LEADER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLeader(Node leader) {
-    this.leader = JsonNullable.<Node>of(leader);
+    this.leader = leader;
   }
 
 
@@ -204,23 +192,12 @@ public class Partition {
     return Objects.equals(this.partition, partition.partition) &&
         Objects.equals(this.replicas, partition.replicas) &&
         Objects.equals(this.isr, partition.isr) &&
-        equalsNullable(this.leader, partition.leader);
-  }
-
-  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
-    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+        Objects.equals(this.leader, partition.leader);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(partition, replicas, isr, hashCodeNullable(leader));
-  }
-
-  private static <T> int hashCodeNullable(JsonNullable<T> a) {
-    if (a == null) {
-      return 1;
-    }
-    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
+    return Objects.hash(partition, replicas, isr, leader);
   }
 
   @Override

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -54,7 +54,7 @@ echo "Generating based on ${OPENAPI_FILENAME}"
 npx @openapitools/openapi-generator-cli generate -g java --library resteasy  -t "$TEMPLATES_DIR"  -i \
     "$OPENAPI_FILENAME.processed" -o "$OUTPUT_PATH" \
     --package-name="${PACKAGE_NAME}" \
-    --additional-properties="apiTests=false,modelTests=false,hideGenerationTimestamp=true,groupId=${GROUP_ID},artifactId=${ARTIFACT_ID},modelPackage=${PACKAGE_NAME}.models,invokerPackage=${PACKAGE_NAME}.invoker,apiPackage=${PACKAGE_NAME},dateLibrary=java8,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt" \
+    --additional-properties="openApiNullable=false,apiTests=false,modelTests=false,hideGenerationTimestamp=true,groupId=${GROUP_ID},artifactId=${ARTIFACT_ID},modelPackage=${PACKAGE_NAME}.models,invokerPackage=${PACKAGE_NAME}.invoker,apiPackage=${PACKAGE_NAME},dateLibrary=java8,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt" \
     --ignore-file-override=.openapi-generator-ignore
 
 GROUP_ID="com.redhat.cloud"


### PR DESCRIPTION
Fixes #233 

Disabled use of `org.openapitools.jackson.nullable.JsonNullable` in generated SDK. Prior to release 0.17 `JsonNullable` was not present in the model. The use of that type requires clients using the SDK to register `JsonNullableModule` in their Jackson `ObjectMapper` instances, similar to the generated code now removed from the `JSON.java` file.