### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/api-update.yaml
+++ b/.github/workflows/api-update.yaml
@@ -39,7 +39,7 @@ jobs:
         run: make generate
       - name: Fetch and Generate Errors SDK
         run: make generateErrors
-      - uses: peter-evans/create-pull-request@v4
+      - uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 #v4
         with:
             title: "fix(${{ github.event.client_payload.id }}): automated SDK update"
             token: "${{ secrets.CI_USER_TOKEN }}"

--- a/.github/workflows/generate_errors.yaml
+++ b/.github/workflows/generate_errors.yaml
@@ -23,7 +23,7 @@ jobs:
         run: ./scripts/errors/fetch-errors.sh
       - name: Generate Errors SDK
         run: ./scripts/errors/generate-errors.sh
-      - uses: peter-evans/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 #v3
         with:
           title: "fix(all): regenerated Error SDK(s)"
           token: "${{ secrets.CI_USER_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG              
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@a362e5fb42057a3a23a62218b050838f1bacca5d #v4
       - name: Validate Tag
         run: npx semver $GITHUB_REF_SLUG
       - name: Version and build kafka-management-sdk
@@ -99,14 +99,14 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}  
       - name: Install git-chglog
-        uses: craicoverflow/install-git-chglog@v1
+        uses: craicoverflow/install-git-chglog@6d338c1d96dcbf12a2115fbe8e5b9817293aae33 #v1
       - name: Generate changelog
         run: |
           echo "CHANGELOG<<EOF" >> $GITHUB_ENV
           echo "$(git-chglog $GITHUB_REF_SLUG 2> /dev/null || echo '**PRERELEASE**')" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Update Release Notes
-        uses: meeDamian/github-release@2.0
+        uses: meeDamian/github-release@7ae19492500104f636b3fee4d8103af0fed36c8e #2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ env.CHANGELOG }}


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
